### PR TITLE
fixed credentials in tests

### DIFF
--- a/src/main/java/fi/helsinki/cs/tmc/cli/tmcstuff/Settings.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/tmcstuff/Settings.java
@@ -26,6 +26,11 @@ public class Settings implements TmcSettings {
     }
 
     public Settings() {
+
+    }
+
+    // TODO: get rid of this shit (use mockito)
+    public Settings(Boolean test) {
         this.serverAddress = System.getenv("TMC_SERVER_ADDRESS");
         this.username = System.getenv("TMC_USERNAME");
         this.password = System.getenv("TMC_PASSWORD");

--- a/src/main/java/fi/helsinki/cs/tmc/cli/tmcstuff/SettingsIo.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/tmcstuff/SettingsIo.java
@@ -31,8 +31,12 @@ public class SettingsIo {
     public static final String ACCOUNTS_CONFIG = "accounts.json";
 
     //The overrideRoot variable is intended only for testing
-    private String overrideRoot;
+    private Path overrideRoot;
 
+    /**
+     * Get the correct directory in which config files go,
+     * NOT the directory in which the config DIRECTORY goes.
+     */
     public static Path getDefaultConfigRoot() {
         Path configPath;
         String os = System.getProperty("os.name").toLowerCase();
@@ -57,9 +61,7 @@ public class SettingsIo {
 
     private Path getAccountsFile(Path path) {
         if (this.overrideRoot != null) {
-            path = Paths.get(this.overrideRoot).resolve(CONFIG_DIR);
-        } else {
-            path = path.resolve(CONFIG_DIR);
+            path = this.overrideRoot;
         }
         Path file = path.resolve(ACCOUNTS_CONFIG);
         if (!Files.exists(path)) {
@@ -138,9 +140,11 @@ public class SettingsIo {
     }
 
     /**
-     * This is for testing purposes only. Otherwise use the default config path.
+     * This is for testing purposes only. Otherwise use the default config dir path.
+     * When calling this function, do not append the CONFIG_DIR - we do it here.
      */
-    protected void setOverrideRoot(String override) {
-        this.overrideRoot = override;
+    protected void setOverrideRoot(Path override) {
+        this.overrideRoot = override
+                .resolve(CONFIG_DIR);
     }
 }

--- a/src/test/java/fi/helsinki/cs/tmc/cli/command/DownloadExercisesCommandTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/command/DownloadExercisesCommandTest.java
@@ -25,7 +25,7 @@ public class DownloadExercisesCommandTest {
     @Before
     public void setUp() {
         app = new Application();
-        app.createTmcCore(new Settings());
+        app.createTmcCore(new Settings(true));
 
         os = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(os);

--- a/src/test/java/fi/helsinki/cs/tmc/cli/command/ListCoursesCommandTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/command/ListCoursesCommandTest.java
@@ -20,7 +20,7 @@ public class ListCoursesCommandTest {
     @Before
     public void setUp() {
         app = new Application();
-        app.createTmcCore(new Settings());
+        app.createTmcCore(new Settings(true));
 
         os = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(os);

--- a/src/test/java/fi/helsinki/cs/tmc/cli/command/ListExercisesCommandTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/command/ListExercisesCommandTest.java
@@ -20,7 +20,7 @@ public class ListExercisesCommandTest {
     @Before
     public void setUp() {
         app = new Application();
-        app.createTmcCore(new Settings());
+        app.createTmcCore(new Settings(true));
 
         os = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(os);

--- a/src/test/java/fi/helsinki/cs/tmc/cli/tmcstuff/SettingsIoTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/tmcstuff/SettingsIoTest.java
@@ -33,7 +33,7 @@ public class SettingsIoTest {
         this.settings = new Settings("testserver", "testuser", "testpassword");
         this.settingsio = new SettingsIo();
         String tempDir = System.getProperty("java.io.tmpdir");
-        settingsio.setOverrideRoot(tempDir);
+        settingsio.setOverrideRoot(Paths.get(tempDir));
         try {
             FileUtils.deleteDirectory(Paths.get(tempDir).resolve("tmc-cli").toFile());
         } catch (Exception e) { }

--- a/src/test/java/fi/helsinki/cs/tmc/cli/tmcstuff/TmcUtilTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/tmcstuff/TmcUtilTest.java
@@ -22,6 +22,7 @@ public class TmcUtilTest {
     @Test
     public void findCouseIfItExists() {
         Course course;
+        app.createTmcCore(new Settings(true));
         course = TmcUtil.findCourse(app.getTmcCore(), "demo");
         assertNotNull(course);
     }


### PR DESCRIPTION
Create new default nop constructor for Settings, so that the gson uses it instead of the testing constructor.
