### PR TITLE
Shutdown hook

### DIFF
--- a/src/main/java/fi/helsinki/cs/tmc/cli/Application.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/Application.java
@@ -186,8 +186,9 @@ public class Application {
     }
 
     public static void main(String[] args) {
-        Runtime.getRuntime().addShutdownHook(new ShutdownHandler());
-        Application app = new Application(new TerminalIo());
+        Io io = new TerminalIo();
+        Runtime.getRuntime().addShutdownHook(new ShutdownHandler(io));
+        Application app = new Application(io);
         app.run(args);
     }
 

--- a/src/main/java/fi/helsinki/cs/tmc/cli/Application.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/Application.java
@@ -186,6 +186,7 @@ public class Application {
     }
 
     public static void main(String[] args) {
+        Runtime.getRuntime().addShutdownHook(new ShutdownHandler());
         Application app = new Application(new TerminalIo());
         app.run(args);
     }

--- a/src/main/java/fi/helsinki/cs/tmc/cli/ShutdownHandler.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/ShutdownHandler.java
@@ -1,10 +1,18 @@
 package fi.helsinki.cs.tmc.cli;
 
+import fi.helsinki.cs.tmc.cli.io.Io;
+
 public class ShutdownHandler extends Thread {
 
     // ANSI escape code that resets console text color back to default.
     // todo: remove this and get it from elsewhere..-
     private static final String ANSI_RESET = "\u001B[0m";
+
+    private final Io io;
+
+    public ShutdownHandler(Io io) {
+        this.io = io;
+    }
 
     /**
      * Executes when the program exits.
@@ -13,7 +21,7 @@ public class ShutdownHandler extends Thread {
     public void run() {
         // Reset terminal color back to default in case we exit in the middle of
         // colored printing. Otherwise user is left with a colored terminal.
-        System.out.println(ANSI_RESET);
+        io.println(ANSI_RESET);
     }
 
 }

--- a/src/main/java/fi/helsinki/cs/tmc/cli/ShutdownHandler.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/ShutdownHandler.java
@@ -1,12 +1,9 @@
 package fi.helsinki.cs.tmc.cli;
 
+import fi.helsinki.cs.tmc.cli.io.Color;
 import fi.helsinki.cs.tmc.cli.io.Io;
 
 public class ShutdownHandler extends Thread {
-
-    // ANSI escape code that resets console text color back to default.
-    // todo: remove this and get it from elsewhere..-
-    private static final String ANSI_RESET = "\u001B[0m";
 
     private final Io io;
 
@@ -21,7 +18,7 @@ public class ShutdownHandler extends Thread {
     public void run() {
         // Reset terminal color back to default in case we exit in the middle of
         // colored printing. Otherwise user is left with a colored terminal.
-        io.println(ANSI_RESET);
+        io.println(Color.ANSI_RESET);
     }
 
 }

--- a/src/main/java/fi/helsinki/cs/tmc/cli/ShutdownHandler.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/ShutdownHandler.java
@@ -1,0 +1,19 @@
+package fi.helsinki.cs.tmc.cli;
+
+public class ShutdownHandler extends Thread {
+
+    // ANSI escape code that resets console text color back to default.
+    // todo: remove this and get it from elsewhere..-
+    private static final String ANSI_RESET = "\u001B[0m";
+
+    /**
+     * Executes when the program exits.
+     */
+    @Override
+    public void run() {
+        // Reset terminal color back to default in case we exit in the middle of
+        // colored printing. Otherwise user is left with a colored terminal.
+        System.out.println(ANSI_RESET);
+    }
+
+}

--- a/src/test/java/fi/helsinki/cs/tmc/cli/ShutdownHandlerTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/ShutdownHandlerTest.java
@@ -1,0 +1,29 @@
+package fi.helsinki.cs.tmc.cli;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import fi.helsinki.cs.tmc.cli.io.Io;
+import fi.helsinki.cs.tmc.cli.io.TerminalIo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShutdownHandlerTest {
+
+    private Io mockIo;
+    private ShutdownHandler shutdownHandler;
+
+    @Before
+    public void setUp() {
+        mockIo = mock(TerminalIo.class);
+        shutdownHandler = new ShutdownHandler(mockIo);
+    }
+
+    @Test
+    public void printsAnsiResetAtRun() {
+        shutdownHandler.run();
+        verify(mockIo).println(eq("\u001B[0m"));
+    }
+}

--- a/src/test/java/fi/helsinki/cs/tmc/cli/ShutdownHandlerTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/cli/ShutdownHandlerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import fi.helsinki.cs.tmc.cli.io.Color;
 import fi.helsinki.cs.tmc.cli.io.Io;
 import fi.helsinki.cs.tmc.cli.io.TerminalIo;
 
@@ -24,6 +25,6 @@ public class ShutdownHandlerTest {
     @Test
     public void printsAnsiResetAtRun() {
         shutdownHandler.run();
-        verify(mockIo).println(eq("\u001B[0m"));
+        verify(mockIo).println(eq(Color.ANSI_RESET));
     }
 }


### PR DESCRIPTION
Resets terminal output color back to default if program exits during colored printing.
