### PR TITLE
Write log file to home/.config/tmc-cli

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -3,9 +3,10 @@ log4j.rootLogger=INFO, file
 
 # Direct log messages to a log file
 log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=logs/tmc-cli.log
+#log4j.appender.file.File=logs/tmc-cli.log
+log4j.appender.file.File=${user.home}/.config/tmc-cli/logs/tmc-cli.log
 log4j.appender.file.MaxFileSize=1MB
-log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.MaxBackupIndex=2
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
  


### PR DESCRIPTION
The program currently writes them to the folder where you launch it and thus leaves a lot of thrash behind.
