### PR TITLE
Do not replace hyphen with fileseparator

### DIFF
--- a/src/main/java/fi/helsinki/cs/tmc/cli/command/RunTestsCommand.java
+++ b/src/main/java/fi/helsinki/cs/tmc/cli/command/RunTestsCommand.java
@@ -76,7 +76,7 @@ public class RunTestsCommand implements CommandInterface {
         try {
             for (String name : exerciseNames) {
                 io.println(Color.colorString("Testing: " + name, Color.ANSI_YELLOW));
-                name = name.replace("-", File.separator);
+                //name = name.replace("-", File.separator);
                 Exercise exercise = new Exercise(name, courseName);
 
                 runResult = core.runTests(new TmcCliProgressObserver(), exercise).call();


### PR DESCRIPTION
Exercises used to be in subfolders so fileseparator was necessary. This issue was fixed in tmc-core.
